### PR TITLE
Add Optional Type Aliasing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,12 +54,14 @@ macro_rules! assign_resources {
     {
         $(
             $group_name:ident : $group_struct:ident {
-                $($resource_name:ident : $resource_field:ident),*
+                $($resource_name:ident : $resource_field:ident $(=$resource_alias:ident)?),*
                 $(,)?
             }
             $(,)?
         )+
     } => {
+        $($($(type $resource_alias = $resource_field;)?)*)*
+
         #[allow(dead_code,non_snake_case)]
         struct _ResourceAssigs {
             $($group_name : $group_struct),*


### PR DESCRIPTION
# Motivation

Functions that refer to types inside "resources" are not helped by the `assign_resources` macro because the types they refer to must still be manually changed.

# Solution

Ability to add type aliases if desired like so:

```rust
assign_resources! {
    status: StatusResources {
        led: PA6
    }
    feedback: FeedbackResources {
        adc: ADC,
        sense: PA2
    }
    hb: HalfBridgeResources {
        timer: TIM1 = PWMTimer,
        control: PA8,
        sync: PA7,
        enable: PA12 = HBEnablePin
    }
    serial: SerialResources {
        uart: USART1,
        rx: PA10,
        tx: PA9
    }
}
```

And use them:

```rust
fn setup_hb<'a>(hb: HalfBridgeResources) -> (ComplementaryPwm<'a, PWMTimer>, Output<'a, HBEnablePin>) { ... }
```

@adamgreig would you like me to change the README/docstring in lib.rs to demonstrate this option?