### PR TITLE
Move pub inside parentheses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ macro_rules! assign_resources {
         $(
             #[allow(dead_code,non_snake_case)]
             struct $group_struct {
-                pub $($resource_name: peripherals::$resource_field),*
+                $(pub $resource_name: peripherals::$resource_field),*
             }
         )+
         macro_rules! split_resources (


### PR DESCRIPTION
This fixes issue #2 by moving the `pub` inside the parentheses.