### PR TITLE
Add Optional Visibility Specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ assign_resources! {
         dm: PA11,
         usb: USB,
     }
-    leds: LedResources {
+    pub leds: LedResources {
         r: PA2,
         g: PA3,
         b: PA4,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,5 +81,36 @@ macro_rules! assign_resources {
                 }
             }
         );
-    }
+    };
+    {
+            $(
+                $pub:vis $group_name:ident : $group_struct:ident {
+                    $($resource_name:ident : $resource_field:ident $(=$resource_alias:ident)?),*
+                    $(,)?
+                }
+                $(,)?
+            )+
+        } => {
+            $($($($pub type $resource_alias = $resource_field;)?)*)*
+
+            #[allow(dead_code,non_snake_case)]
+            struct _ResourceAssigs {
+                $($group_name : $group_struct),*
+            }
+            $(
+                #[allow(dead_code,non_snake_case)]
+                $pub struct $group_struct {
+                    $(pub $resource_name: peripherals::$resource_field),*
+                }
+            )+
+            macro_rules! split_resources (
+                ($p:ident) => {
+                    _ResourceAssigs {
+                        $($group_name: $group_struct {
+                            $($resource_name: $p.$resource_field),*
+                        }),*
+                    }
+                }
+            );
+        }
 }


### PR DESCRIPTION
# Motivation

Using the generated resource types in locations external to macro invocation is not possible.

# Solution

Add the ability to write `pub` in front of whatever resources you want to be public.

Like so:

```rust
assign_resources! {
    status: StatusResources {
        led: PA6 = StatusPin
    }
    feedback: FeedbackResources {
        adc: ADC,
        sense: PA2
    }
    hb: HalfBridgeResources {
        timer: TIM1 = PWMTimer,
        control: PA8,
        sync: PA7,
        enable: PA12 = HBEnablePin
    }
    pub serial: SerialResources {
        uart: USART1,
        rx: PA10,
        tx: PA9
    }
}
```

# Changes

- lib.rs: Implementation
- README.md: Updated example to reflect capability

# Caveats

I had to basically duplicate the whole macro to have two variants one with pub and one without and I don't like that so much code is duplicated. Perhaps this should be a proc-macro (I would be happy to do that) or maybe there's some way to do non-trailing conditionals I don't know about.