### PR TITLE
Allow missing docs for pub type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ macro_rules! assign_resources {
             }
         )+
 
+        #[allow(missing_docs)]
         $($($(pub type $resource_alias = peripherals::$resource_field;)?)*)*
 
         #[macro_export]


### PR DESCRIPTION
Just realized that the 0.4.0 version errors when you deny(missing_docs).
I overlooked that this would happen with the last change to my last pr (adding the `pub` to the type alias).