### PR TITLE
Move #[allow(missing_docs)] to the type alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,8 +82,11 @@ macro_rules! assign_resources {
             }
         )+
 
-        #[allow(missing_docs)]
-        $($($(pub type $resource_alias = peripherals::$resource_field;)?)*)*
+
+        $($($(
+            #[allow(missing_docs)]
+            pub type $resource_alias = peripherals::$resource_field;
+        )?)*)*
 
         #[macro_export]
         /// `split_resources!` macro


### PR DESCRIPTION
#6 only fixed the issue for one type alias. When there are multiple, it won't work with the current implementation since it is not repeated.