### PR TITLE
Repeat attributes in AssignedResources struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,10 @@ macro_rules! assign_resources {
             ($p:ident) => {
                 AssignedResources {
                     $($group_name: $group_struct {
-                        $($resource_name: $p.$resource_field),*
+                        $(
+                            $(#[$inner])*
+                            $resource_name: $p.$resource_field
+                        ),*
                     }),*
                 }
             }


### PR DESCRIPTION
Currently the attributes are not repeated in the `AssignedResources`  struct. However, related to #9 they should probably be to make feature attributes work.