### PR TITLE
Overload the macro to provide a better error message if a path is provided.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ macro_rules! assign_resources {
         )+
     } => {
         compile_error!(
-            "This macro does not take full paths to the types, instead it expects `peripherals` and `Peri` to exist in the current scope and one passes in just the names of the peripherals. Like `use embassy_stm32::{peripherals, Peri};` or `use embassy_rp::{peripherals, Peri};`."
+            "Instead of a path, pass the name of the peripheral directly."
         );
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,5 +99,21 @@ macro_rules! assign_resources {
                 }
             }
         );
-    }
+    };
+    {
+        $(
+            $(#[$outer:meta])*
+            $group_name:ident : $group_struct:ident {
+                $(
+                    $(#[$inner:meta])*
+                    $resource_name:ident : $resource_field:path $(=$resource_alias:ident)?),*
+                $(,)?
+            }
+            $(,)?
+        )+
+    } => {
+        compile_error!(
+            "This macro does not take full paths to the types, instead it expects `peripherals` and `Peri` to exist in the current scope and one passes in just the names of the peripherals. Like `use embassy_stm32::{peripherals, Peri};` or `use embassy_rp::{peripherals, Peri};`."
+        );
+    };
 }


### PR DESCRIPTION
Hi, I explored this crate after reading about it in [this embassy issue](https://github.com/embassy-rs/embassy/issues/4868), I subsequently ended up with code adapted from the example like:

```rust
use assign_resources::assign_resources;
assign_resources! {
    temperature: AdcResources {
        adc_channel:  embassy_rp::peripherals::ADC_TEMP_SENSOR,
        adc: embassy_rp::peripherals::ADC,
    }
}
```

That unfortunately did not work and led to the following vague error:
```
error: no rules expected `::`
   --> src/hap.rs:546:33
    |
546 |         adc_channel:  embassy_rp::peripherals::ADC_TEMP_SENSOR,
    |                                 ^^ no rules expected this token in macro call
    |
note: while trying to match `}`
   --> /workspace/ivor/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/assign-resources-0.5.0/src/lib.rs:66:13
    |
 66 |             }
    |             ^

error: could not compile `example_pico_2w` (lib) due to 1 previous error
```

I only figured out what was wrong after reading the source code of this macro, then discovered #8, so thought we could improve that by overloading the input arguments with the `:path` input type. This only matches if `ident` doesn't match, in which case we can get a nice(r) error message like this:

```
error: This macro does not take full paths to the types, instead it expects `peripherals` and `Peri` to exist in the current scope and one passes in just the names of the peripherals. Like `use embassy_stm32::{peripherals, Peri};` or `use embassy_rp::{peripherals, Peri};`.
   --> src/hap.rs:544:1
    |
544 | / assign_resources! {
545 | |     temperature: AdcResources {
546 | |         adc_channel:  embassy_rp::peripherals::ADC_TEMP_SENSOR,
547 | |         adc: ADC,
548 | |     }
549 | | }
    | |_^
    |
    = note: this error originates in the macro `assign_resources` (in Nightly builds, run with -Z macro-backtrace for more info)
```

I'm not sure if I'm actually going to use this crate, but thought I'd file a PR immediately to improve this error message at least to hopefully prevent others from being surprised.

PS. Rustfmt doesn't wrap the sentence in the `compile_error`, and manually wrapping it results in newlines in the compile error and incorrect indentation, also not too sure on the wording, happy to change that as you see fit.